### PR TITLE
🔀 chore(Layout.astro): update font paths to use absolute paths for be…

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,8 +27,8 @@ const { title } = Astro.props;
 <style is:global>
 	@font-face {
 		font-family: "Hanken Grotesk";
-		src: url("./fonts/HankenGrotesk-Medium.woff2") format("woff2"),
-			url("./fonts/HankenGrotesk-Medium.woff") format("woff");
+		src: url("/fonts/HankenGrotesk-Medium.woff2") format("woff2"),
+			url("/fonts/HankenGrotesk-Medium.woff") format("woff");
 		font-weight: 500;
 		font-style: normal;
 		font-display: swap;
@@ -36,8 +36,8 @@ const { title } = Astro.props;
 
 	@font-face {
 		font-family: "Hanken Grotesk";
-		src: url("./fonts/HankenGrotesk-Bold.woff2") format("woff2"),
-			url("./fonts/HankenGrotesk-Bold.woff") format("woff");
+		src: url("/fonts/HankenGrotesk-Bold.woff2") format("woff2"),
+			url("/fonts/HankenGrotesk-Bold.woff") format("woff");
 		font-weight: bold;
 		font-style: normal;
 		font-display: swap;
@@ -45,8 +45,8 @@ const { title } = Astro.props;
 
 	@font-face {
 		font-family: "Hanken Grotesk";
-		src: url("./fonts/HankenGrotesk-ExtraBold.woff2") format("woff2"),
-			url("./fonts/HankenGrotesk-ExtraBold.woff") format("woff");
+		src: url("/fonts/HankenGrotesk-ExtraBold.woff2") format("woff2"),
+			url("/fonts/HankenGrotesk-ExtraBold.woff") format("woff");
 		font-weight: bold;
 		font-style: normal;
 		font-display: swap;


### PR DESCRIPTION
Revise y las fuentes no estaban cargando, y era porque debíamos colocar la ruta sin el `./` y dejar solamente el `/`